### PR TITLE
Lint $sce on 'this' expressions

### DIFF
--- a/lib/rules/detect-angular-trustAs-methods.js
+++ b/lib/rules/detect-angular-trustAs-methods.js
@@ -9,14 +9,21 @@ module.exports = {
 
   create: function (context) {
     return {
-      MemberExpression: function (node) {
-          if (node.object.name == "$sce" && node.property.name == "trustAs") {
-            context.report(node, `The use of $sce.trustAs can be dangerous`);
-          }
+      "CallExpression[callee.property.name=trustAs][callee.object.name=$sce]": function (node) {
+        if (node.arguments[1] && node.arguments[1].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAs can be dangerous`);
+        }
       },
-      "MemberExpression[property.name='trustAs'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
-        context.report(node, `The use of $sce.trustAs can be dangerous`);
-    }
+      "CallExpression[callee.property.name=trustAs] MemberExpression[property.name=$sce]": function (node) {
+        var args = node.parent.parent.arguments;
+        if (args && args[1].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAs can be dangerous`);
+        }
+      }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAs-methods.js
+++ b/lib/rules/detect-angular-trustAs-methods.js
@@ -13,7 +13,10 @@ module.exports = {
           if (node.object.name == "$sce" && node.property.name == "trustAs") {
             context.report(node, `The use of $sce.trustAs can be dangerous`);
           }
-      }
+      },
+      "MemberExpression[property.name='trustAs'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+        context.report(node, `The use of $sce.trustAs can be dangerous`);
+    }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsCss-method.js
+++ b/lib/rules/detect-angular-trustAsCss-method.js
@@ -13,7 +13,10 @@ module.exports = {
           if (node.object.name == "$sce" && node.property.name == "trustAsCss") {
             context.report(node, `The use of $sce.trustAsCss can be dangerous`);
           }
-      }
+      },
+      "MemberExpression[property.name='trustAsCss'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+        context.report(node, `The use of $sce.trustAsCss can be dangerous`);
+    }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsCss-method.js
+++ b/lib/rules/detect-angular-trustAsCss-method.js
@@ -9,14 +9,21 @@ module.exports = {
 
   create: function (context) {
     return {
-      MemberExpression: function (node) {
-          if (node.object.name == "$sce" && node.property.name == "trustAsCss") {
-            context.report(node, `The use of $sce.trustAsCss can be dangerous`);
-          }
+      "CallExpression[callee.property.name=trustAsCss][callee.object.name=$sce]": function (node) {
+        if (node.arguments[0] && node.arguments[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsCss can be dangerous`);
+        }
       },
-      "MemberExpression[property.name='trustAsCss'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
-        context.report(node, `The use of $sce.trustAsCss can be dangerous`);
-    }
+      "CallExpression[callee.property.name=trustAsCss] MemberExpression[property.name=$sce]": function (node) {
+        var args = node.parent.parent.arguments;
+        if (args && args[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsCss can be dangerous`);
+        }
+      }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsHtml-method.js
+++ b/lib/rules/detect-angular-trustAsHtml-method.js
@@ -13,7 +13,10 @@ module.exports = {
           if (node.object.name == "$sce" && node.property.name == "trustAsHtml") {
             context.report(node, `The use of $sce.trustAsHtml can be dangerous`);
           }
-      }
+      },
+      "MemberExpression[property.name='trustAsHtml'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+        context.report(node, `The use of $sce.trustAsHtml can be dangerous`);
+    }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsHtml-method.js
+++ b/lib/rules/detect-angular-trustAsHtml-method.js
@@ -9,14 +9,21 @@ module.exports = {
 
   create: function (context) {
     return {
-      MemberExpression: function (node) {
-          if (node.object.name == "$sce" && node.property.name == "trustAsHtml") {
-            context.report(node, `The use of $sce.trustAsHtml can be dangerous`);
-          }
+      "CallExpression[callee.property.name=trustAsHtml][callee.object.name=$sce]": function (node) {
+        if (node.arguments[0] && node.arguments[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsHtml can be dangerous`);
+        }
       },
-      "MemberExpression[property.name='trustAsHtml'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
-        context.report(node, `The use of $sce.trustAsHtml can be dangerous`);
-    }
+      "CallExpression[callee.property.name=trustAsHtml] MemberExpression[property.name=$sce]": function (node) {
+        var args = node.parent.parent.arguments;
+        if (args && args[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsHtml can be dangerous`);
+        }
+      }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsJs-method.js
+++ b/lib/rules/detect-angular-trustAsJs-method.js
@@ -13,6 +13,9 @@ module.exports = {
           if (node.object.name == "$sce" && node.property.name == "trustAsJs") {
             context.report(node, `The use of $sce.trustAsJs can be dangerous`);
           }
+      },
+      "MemberExpression[property.name='trustAsJs'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+          context.report(node, `The use of $sce.trustAsJs can be dangerous`);
       }
     };
   }

--- a/lib/rules/detect-angular-trustAsJs-method.js
+++ b/lib/rules/detect-angular-trustAsJs-method.js
@@ -9,13 +9,20 @@ module.exports = {
 
   create: function (context) {
     return {
-      MemberExpression: function (node) {
-          if (node.object.name == "$sce" && node.property.name == "trustAsJs") {
-            context.report(node, `The use of $sce.trustAsJs can be dangerous`);
-          }
-      },
-      "MemberExpression[property.name='trustAsJs'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+      "CallExpression[callee.property.name=trustAsJs][callee.object.name=$sce]": function (node) {
+        if (node.arguments[0] && node.arguments[0].type === 'Literal') {
+          return;
+        } else {
           context.report(node, `The use of $sce.trustAsJs can be dangerous`);
+        }
+      },
+      "CallExpression[callee.property.name=trustAsJs] MemberExpression[property.name=$sce]": function (node) {
+        var args = node.parent.parent.arguments;
+        if (args && args[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsJs can be dangerous`);
+        }
       }
     };
   }

--- a/lib/rules/detect-angular-trustAsResourceUrl-method.js
+++ b/lib/rules/detect-angular-trustAsResourceUrl-method.js
@@ -13,7 +13,10 @@ module.exports = {
           if (node.object.name == "$sce" && node.property.name == "trustAsResourceUrl") {
             context.report(node, `The use of $sce.trustAsResourceUrl can be dangerous`);
           }
-      }
+      },
+      "MemberExpression[property.name='trustAsResourceUrl'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+        context.report(node, `The use of $sce.trustAsResourceUrl can be dangerous`);
+    }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsResourceUrl-method.js
+++ b/lib/rules/detect-angular-trustAsResourceUrl-method.js
@@ -9,14 +9,21 @@ module.exports = {
 
   create: function (context) {
     return {
-      MemberExpression: function (node) {
-          if (node.object.name == "$sce" && node.property.name == "trustAsResourceUrl") {
-            context.report(node, `The use of $sce.trustAsResourceUrl can be dangerous`);
-          }
+      "CallExpression[callee.property.name=trustAsResourceUrl][callee.object.name=$sce]": function (node) {
+        if (node.arguments[0] && node.arguments[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsResourceUrl can be dangerous`);
+        }
       },
-      "MemberExpression[property.name='trustAsResourceUrl'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
-        context.report(node, `The use of $sce.trustAsResourceUrl can be dangerous`);
-    }
+      "CallExpression[callee.property.name=trustAsResourceUrl] MemberExpression[property.name=$sce]": function (node) {
+        var args = node.parent.parent.arguments;
+        if (args && args[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsResourceUrl can be dangerous`);
+        }
+      }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsUrl-method.js
+++ b/lib/rules/detect-angular-trustAsUrl-method.js
@@ -13,7 +13,10 @@ module.exports = {
           if (node.object.name == "$sce" && node.property.name == "trustAsUrl") {
             context.report(node, `The use of $sce.trustAsUrl can be dangerous`);
           }
-      }
+      },
+      "MemberExpression[property.name='trustAsUrl'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
+        context.report(node, `The use of $sce.trustAsUrl can be dangerous`);
+    }
     };
   }
 };

--- a/lib/rules/detect-angular-trustAsUrl-method.js
+++ b/lib/rules/detect-angular-trustAsUrl-method.js
@@ -9,14 +9,21 @@ module.exports = {
 
   create: function (context) {
     return {
-      MemberExpression: function (node) {
-          if (node.object.name == "$sce" && node.property.name == "trustAsUrl") {
-            context.report(node, `The use of $sce.trustAsUrl can be dangerous`);
-          }
+      "CallExpression[callee.property.name=trustAsUrl][callee.object.name=$sce]": function (node) {
+        if (node.arguments[0] && node.arguments[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsUrl can be dangerous`);
+        }
       },
-      "MemberExpression[property.name='trustAsUrl'] MemberExpression[property.name='$sce'] ThisExpression": function (node) {
-        context.report(node, `The use of $sce.trustAsUrl can be dangerous`);
-    }
+      "CallExpression[callee.property.name=trustAsUrl] MemberExpression[property.name=$sce]": function (node) {
+        var args = node.parent.parent.arguments;
+        if (args && args[0].type === 'Literal') {
+          return;
+        } else {
+          context.report(node, `The use of $sce.trustAsUrl can be dangerous`);
+        }
+      }
     };
   }
 };

--- a/tests/rules/detect-angular-trustAs-methods.js
+++ b/tests/rules/detect-angular-trustAs-methods.js
@@ -19,11 +19,18 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAs-methods", rule, {
   valid: [
-    { code: "$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
-  ],    
+    { code: "$sce.ParseAsHtml()" },
+    { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
+  ],  
   invalid: [
     {
       code: "$sce.trustAs($sce.HTML, value);",
+      errors: [
+        { message: "The use of $sce.trustAs can be dangerous" }
+      ],
+    },
+    {
+      code: "this.$sce.trustAs($sce.HTML, value);",
       errors: [
         { message: "The use of $sce.trustAs can be dangerous" }
       ],
@@ -41,7 +48,25 @@ eslintTester.run("detect-angular-trustAs-methods", rule, {
       ],
     },
     {
+      code: "this.$sce.trustAs($sce.JS, value);",
+      errors: [
+        { message: "The use of $sce.trustAs can be dangerous" }
+      ],
+    },
+    {
       code: "$sce.trustAs($sce.RESOURCE_URL, value);",
+      errors: [
+        { message: "The use of $sce.trustAs can be dangerous" }
+      ],
+    },
+    {
+      code: "this.$sce.trustAs($sce.RESOURCE_URL, value);",
+      errors: [
+        { message: "The use of $sce.trustAs can be dangerous" }
+      ],
+    },
+    {
+      code: "this.$sce.trustAs($sce.URL, value);",
       errors: [
         { message: "The use of $sce.trustAs can be dangerous" }
       ],

--- a/tests/rules/detect-angular-trustAs-methods.js
+++ b/tests/rules/detect-angular-trustAs-methods.js
@@ -19,6 +19,8 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAs-methods", rule, {
   valid: [
+    { code: "this.$sce.trustAs($sce.HTML, 'stringLiteralValue');" }, // string literals are OK
+    { code: "$sce.trustAs($sce.HTML, 'stringLiteralValue');" },
     { code: "$sce.ParseAsHtml()" },
     { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
   ],  

--- a/tests/rules/detect-angular-trustAsCss-method.js
+++ b/tests/rules/detect-angular-trustAsCss-method.js
@@ -19,6 +19,7 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsCss-method", rule, {
   valid: [
+    { code: "$sce.trustAsCss('stringLiteral');" }, // string literals are OK
     { code: "$sce.ParseAsHtml()" },
     { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
   ],   

--- a/tests/rules/detect-angular-trustAsCss-method.js
+++ b/tests/rules/detect-angular-trustAsCss-method.js
@@ -19,11 +19,18 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsCss-method", rule, {
   valid: [
-    { code: "$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
-  ],    
+    { code: "$sce.ParseAsHtml()" },
+    { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
+  ],   
   invalid: [
     {
       code: "$sce.trustAsCss(value);",
+      errors: [
+        { message: "The use of $sce.trustAsCss can be dangerous" }
+      ],
+    },
+    {
+      code: "this.$sce.trustAsCss(value);",
       errors: [
         { message: "The use of $sce.trustAsCss can be dangerous" }
       ],

--- a/tests/rules/detect-angular-trustAsHtml-method.js
+++ b/tests/rules/detect-angular-trustAsHtml-method.js
@@ -19,14 +19,21 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsHtml-method", rule, {
   valid: [
-    { code: "$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
-  ],    
+    { code: "$sce.ParseAsHtml()" },
+    { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
+  ],  
   invalid: [
     {
       code: "$sce.trustAsHtml(value);",
       errors: [
         { message: "The use of $sce.trustAsHtml can be dangerous" }
       ],
-    }
+    },
+    {
+      code: "this.$sce.trustAsHtml(value);",
+      errors: [
+        { message: "The use of $sce.trustAsHtml can be dangerous" }
+      ],
+    },
   ]
 }); 

--- a/tests/rules/detect-angular-trustAsHtml-method.js
+++ b/tests/rules/detect-angular-trustAsHtml-method.js
@@ -19,6 +19,7 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsHtml-method", rule, {
   valid: [
+    { code: "$sce.trustAsHtml('stringLiteral');" }, // string literals are OK
     { code: "$sce.ParseAsHtml()" },
     { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
   ],  

--- a/tests/rules/detect-angular-trustAsJs-method.js
+++ b/tests/rules/detect-angular-trustAsJs-method.js
@@ -19,11 +19,18 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsJs-method", rule, {
   valid: [
-    { code: "$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
+    { code: "$sce.ParseAsHtml()" },
+    { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
   ],    
   invalid: [
     {
       code: "$sce.trustAsJs(value);",
+      errors: [
+        { message: "The use of $sce.trustAsJs can be dangerous" }
+      ],
+    },
+    {
+      code: "this.$sce.trustAsJs(value);",
       errors: [
         { message: "The use of $sce.trustAsJs can be dangerous" }
       ],

--- a/tests/rules/detect-angular-trustAsJs-method.js
+++ b/tests/rules/detect-angular-trustAsJs-method.js
@@ -19,6 +19,7 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsJs-method", rule, {
   valid: [
+    { code: "$sce.trustAsJs('stringLiteral');" }, // string literals are OK
     { code: "$sce.ParseAsHtml()" },
     { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
   ],    

--- a/tests/rules/detect-angular-trustAsResouceUrl-method.js
+++ b/tests/rules/detect-angular-trustAsResouceUrl-method.js
@@ -19,11 +19,18 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsResourceUrl-method", rule, {
   valid: [
-    { code: "$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
-  ],    
+    { code: "$sce.ParseAsHtml()" },
+    { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
+  ],  
   invalid: [
     {
       code: "$sce.trustAsResourceUrl(value);",
+      errors: [
+        { message: "The use of $sce.trustAsResourceUrl can be dangerous" }
+      ],
+    },
+    {
+      code: "this.$sce.trustAsResourceUrl(value);",
       errors: [
         { message: "The use of $sce.trustAsResourceUrl can be dangerous" }
       ],

--- a/tests/rules/detect-angular-trustAsResouceUrl-method.js
+++ b/tests/rules/detect-angular-trustAsResouceUrl-method.js
@@ -19,6 +19,7 @@ var eslintTester = new RuleTester();
 
 eslintTester.run("detect-angular-trustAsResourceUrl-method", rule, {
   valid: [
+    { code: "$sce.trustAsResourceUrl('stringLiteral');" }, // string literals are OK
     { code: "$sce.ParseAsHtml()" },
     { code: "this.$sce.ParseAsHtml()" } // no need to look for valid as we are just doing detection 
   ],  


### PR DESCRIPTION
When AngularJS controllers are defined as ES6 classes, injectables
such as $sce are typically passed into the constructor and set as
instance properties of the class.  This change will detect calls to
trustAs* methods in es6 classes.