### PR TITLE
Fix name undefined

### DIFF
--- a/lib/rules/detect-angular-open-redirect.js
+++ b/lib/rules/detect-angular-open-redirect.js
@@ -9,7 +9,7 @@ module.exports = {
   create: function (context) {
     return {
       MemberExpression: function (node) {
-        if (node.object.name === '$window' && node.property.name === 'location' && node.parent.property.name === 'href') {
+        if (node.object.name === '$window' && node.property.name === 'location' && node.parent.property && node.parent.property.name === 'href') {
           context.report(node, "Use of $window.location.href can lead to open-redirect");
         };
       }


### PR DESCRIPTION
Added `undefined` property check in detect-angular-open-redirect rule.
Without check sometimes scan fails:
```
TypeError: Cannot read property 'name' of undefined
Occurred while linting /root/Desktop/webapps2/webapp-0.1.0.js:432725
    at MemberExpression (/root/eslint-security-scanner-configs/node_modules/eslint-plugin-angularjs-security-rules/lib/rules/detect-angular-open-redirect.js:12:105)
    at /root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/node-event-generator.js:254:26)
    at NodeEventGenerator.applySelectors (/root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/node-event-generator.js:283:22)
    at NodeEventGenerator.enterNode (/root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/node-event-generator.js:297:14)
    at CodePathAnalyzer.enterNode (/root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:634:23)
    at /root/eslint-security-scanner-configs/node_modules/eslint/lib/linter/linter.js:936:32
    at Array.forEach (<anonymous>)
```